### PR TITLE
chore: fix CI perms

### DIFF
--- a/.github/workflows/validate-scripts.yml
+++ b/.github/workflows/validate-scripts.yml
@@ -21,6 +21,9 @@ on:
       - 'tests/*.bats'
       - README.md
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/michen00/bin/security/code-scanning/3](https://github.com/michen00/bin/security/code-scanning/3)

In general, the fix is to add an explicit `permissions` block to the workflow or to the specific job so the `GITHUB_TOKEN` has only the minimal required permissions (here, likely just `contents: read`). This documents the workflow’s needs and prevents it from accidentally gaining broader permissions if org/repo defaults change.

The single best way to fix this without changing functionality is to add a workflow-level `permissions` section near the top of `.github/workflows/validate-scripts.yml`, after the `on:` block (or before `concurrency:`), setting `contents: read`. This will apply to all jobs (currently just `validate`) that don’t override permissions, and is sufficient for `actions/checkout@v6` and reading repo files. No other scopes (like `pull-requests` or `issues`) are required by the shown steps. No imports or external dependencies are needed; we only modify the YAML configuration.

Concretely, in `.github/workflows/validate-scripts.yml`, between the `push:` block ending at line 22 and the `concurrency:` block starting at line 24, insert:

```yaml
permissions:
  contents: read
```

This change constrains `GITHUB_TOKEN` to read-only repository contents while preserving existing behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
