### PR TITLE
feat(git-shed): harden worktree removal and add --gone-only

### DIFF
--- a/git-shed
+++ b/git-shed
@@ -3,35 +3,34 @@
 set -euo pipefail
 
 # original author: @ragavi-ashok
+# hardened worktree handling; --gone-only for upstream-deleted branches only
 
 HELP=$(
 	cat <<EOF
-Usage: $(basename "$0") [-y] [--dry-run] [TARGET_BRANCH]
-Usage Example: $(basename "$0") -y --dry-run my-branch
+Usage: $(basename "$0") [-y] [--dry-run] [--gone-only] [TARGET_BRANCH]
 
 Arguments:
-  TARGET_BRANCH  The branch to compare against for merged branches. Defaults to 'main'.
+  TARGET_BRANCH  Branch to compare for merged locals. Defaults to 'main'. Ignored with --gone-only.
 
 Options:
-  -h, --help     Show this help message and exit.
-  -y             Automatically confirm deletion of merged and stale branches.
-  --dry-run      Only show what would be deleted, without making changes.
+  -h, --help     Show this help and exit.
+  -y             Confirm deletion without prompting.
+  --dry-run      Show what would be deleted; make no changes.
+  --gone-only    Only delete branches whose upstream was removed on the remote ([gone]).
 
 Description:
-  This script performs the following actions:
-  1. Fetches the latest remote information and prunes deleted branches.
-  2. Identifies local branches that are fully merged into the TARGET_BRANCH.
-  3. Prompts the user (or automatically confirms with -y) to delete these merged branches.
-  4. Identifies local branches that no longer have a remote.
-  5. Prompts the user (or automatically confirms with -y) to delete these stale branches.
+  1. git fetch --prune (non-fatal if fetch fails)
+  2. Unless --gone-only: delete local branches merged into TARGET_BRANCH (or origin/TARGET_BRANCH)
+  3. Delete local branches whose upstream no longer exists ([gone])
+  Linked worktrees are removed before branch delete when needed.
 EOF
 )
 
 AUTO_CONFIRM=false
 DRY_RUN=false
+GONE_ONLY=false
 TARGET_BRANCH=""
 
-# Parse options
 while [[ $# -gt 0 ]]; do
 	case "$1" in
 	-h | --help)
@@ -46,6 +45,15 @@ while [[ $# -gt 0 ]]; do
 		DRY_RUN=true
 		shift
 		;;
+	--gone-only)
+		GONE_ONLY=true
+		shift
+		;;
+	-*)
+		echo "Unknown option: $1" >&2
+		echo "$HELP" >&2
+		exit 2
+		;;
 	*)
 		TARGET_BRANCH="$1"
 		shift
@@ -55,82 +63,137 @@ done
 
 TARGET_BRANCH=${TARGET_BRANCH:-main}
 
-if ! git show-ref --verify --quiet "refs/heads/$TARGET_BRANCH"; then
-	echo "Error: Branch '$TARGET_BRANCH' does not exist."
-	exit 1
+if ! $GONE_ONLY; then
+	if ! git show-ref --verify --quiet "refs/heads/$TARGET_BRANCH"; then
+		echo "Error: Branch '$TARGET_BRANCH' does not exist."
+		exit 1
+	fi
 fi
 
 echo "Fetching latest remote info and pruning..."
-# git fetch may fail if no remote is configured or network issues occur
-# This is non-fatal - we can still proceed with local branch analysis
 if ! git fetch --prune 2>/dev/null; then
-	echo "Warning: git fetch failed (this is non-fatal)" >&2
+	echo "Warning: git fetch --prune failed (non-fatal; continuing with local state)" >&2
 fi
 
-# Identify local branches fully merged into the remote target branch.
-# Using origin/$TARGET_BRANCH ensures we compare against the up-to-date remote.
-# Wrap in subshell so filtering applies to both the primary and fallback command.
-# Use awk so an empty result doesn't trip pipefail (grep -v returns 1 on no matches).
-MERGED_BRANCHES=$(
-	(git branch --merged "origin/$TARGET_BRANCH" 2>/dev/null ||
-		git branch --merged "$TARGET_BRANCH") |
-		awk -v target="$TARGET_BRANCH" '
-			/^\*/ { next }
-			{
-				sub(/^  /, "")
-				if ($0 != target) print
-			}
-		'
-)
+echo ""
+echo "Local branches:"
+git branch -v
 
-if [ -z "$MERGED_BRANCHES" ]; then
-	echo "No local branches merged into '$TARGET_BRANCH' found. Nothing to clean."
-else
-	echo "The following branches are fully merged into '$TARGET_BRANCH':"
-	echo "$MERGED_BRANCHES"
-	if $AUTO_CONFIRM; then
-		CONFIRM="y"
-	else
-		read -r -p "Do you want to delete these merged branches? [y/N]: " CONFIRM
+echo ""
+echo "Worktrees:"
+git worktree list
+
+remove_linked_worktree_for_branch() {
+	local branch=$1
+	local toplevel worktree
+	toplevel=$(git rev-parse --show-toplevel)
+	worktree=$(
+		git worktree list | grep -F "[$branch]" | awk '{print $1}' || true
+	)
+	if [[ -z "$worktree" || "$worktree" == "$toplevel" ]]; then
+		return 0
 	fi
-	if [[ $CONFIRM =~ ^[Yy]$ ]]; then
-		for BRANCH in $MERGED_BRANCHES; do
-			if $DRY_RUN; then
-				echo "[DRY-RUN] Would delete merged branch: $BRANCH"
-			else
-				git branch -d "$BRANCH"
-			fi
-		done
-	else
-		echo "Skipping deletion of merged branches."
+	if $DRY_RUN; then
+		echo "[DRY-RUN] Would remove worktree: $worktree (checks out $branch)"
+		return 0
 	fi
+	echo "Removing worktree: $worktree"
+	if ! git worktree remove --force "$worktree"; then
+		echo "Retrying worktree remove with --force --force..." >&2
+		git worktree remove --force --force "$worktree" || return 1
+	fi
+	return 0
+}
+
+delete_merged_branches() {
+	local merged_into=$1
+	local merged_branches
+	merged_branches=$(
+		git for-each-ref --format='%(refname:short)' --merged="$merged_into" refs/heads/ |
+			grep -vxF "$TARGET_BRANCH" || true
+	)
+
+	echo ""
+	if [[ -z "$merged_branches" ]]; then
+		echo "No local branches merged into '$merged_into' found."
+		return 0
+	fi
+
+	echo "Branches fully merged into '$merged_into':"
+	echo "$merged_branches" | sed 's/^/  /'
+
+	if ! $AUTO_CONFIRM && ! $DRY_RUN; then
+		read -r -p "Delete these merged branches? [y/N]: " CONFIRM
+		if [[ ! $CONFIRM =~ ^[Yy]$ ]]; then
+			echo "Skipping deletion of merged branches."
+			return 0
+		fi
+	fi
+
+	for branch in $merged_branches; do
+		echo ""
+		echo "Processing merged branch: $branch"
+		if $DRY_RUN; then
+			remove_linked_worktree_for_branch "$branch"
+			echo "[DRY-RUN] Would delete merged branch: $branch"
+			continue
+		fi
+		if ! remove_linked_worktree_for_branch "$branch"; then
+			echo "Warning: skipping merged branch '$branch' (worktree removal failed)." >&2
+			continue
+		fi
+		git branch -d "$branch" || echo "Warning: could not delete merged branch '$branch'." >&2
+	done
+}
+
+delete_gone_branches() {
+	local stale_branches
+	stale_branches=$(
+		git branch -vv | awk '/: gone]/ { print ($1 == "*" || $1 == "+" ? $2 : $1) }'
+	)
+
+	echo ""
+	if [[ -z "$stale_branches" ]]; then
+		echo "No stale branches (upstream deleted on remote) found."
+		return 0
+	fi
+
+	echo "Branches with deleted upstream ([gone]):"
+	echo "$stale_branches" | sed 's/^/  /'
+
+	if ! $AUTO_CONFIRM && ! $DRY_RUN; then
+		read -r -p "Delete these stale branches? [y/N]: " CONFIRM_STALE
+		if [[ ! $CONFIRM_STALE =~ ^[Yy]$ ]]; then
+			echo "Skipping deletion of stale branches."
+			return 0
+		fi
+	fi
+
+	for branch in $stale_branches; do
+		echo ""
+		echo "Processing stale branch: $branch"
+		if $DRY_RUN; then
+			remove_linked_worktree_for_branch "$branch"
+			echo "[DRY-RUN] Would delete stale branch: $branch"
+			continue
+		fi
+		if ! remove_linked_worktree_for_branch "$branch"; then
+			echo "Warning: skipping stale branch '$branch' (worktree removal failed)." >&2
+			continue
+		fi
+		git branch -D "$branch" || echo "Warning: could not delete stale branch '$branch'." >&2
+	done
+}
+
+if ! $GONE_ONLY; then
+	MERGED_INTO="origin/$TARGET_BRANCH"
+	if ! git rev-parse --verify --quiet "$MERGED_INTO" >/dev/null; then
+		MERGED_INTO="$TARGET_BRANCH"
+	fi
+	delete_merged_branches "$MERGED_INTO"
 fi
 
-# Identify local branches that no longer have a remote.
-# Use -vv to show tracking info; ": gone]" indicates deleted upstream
-STALE_BRANCHES=$(git branch -vv | awk '/: gone]/ {print ($1 == "*" ? $2 : $1)}')
+delete_gone_branches
 
-if [ -z "$STALE_BRANCHES" ]; then
-	echo "No stale branches (i.e., branches with no remote) found."
-else
-	echo "The following branches have no remote and might be stale:"
-	echo "$STALE_BRANCHES"
-	if $AUTO_CONFIRM; then
-		CONFIRM_STALE="y"
-	else
-		read -r -p "Do you want to delete these stale branches? [y/N]: " CONFIRM_STALE
-	fi
-	if [[ $CONFIRM_STALE =~ ^[Yy]$ ]]; then
-		for BRANCH in $STALE_BRANCHES; do
-			if $DRY_RUN; then
-				echo "[DRY-RUN] Would delete stale branch: $BRANCH"
-			else
-				git branch -D "$BRANCH"
-			fi
-		done
-	else
-		echo "Skipping deletion of stale branches."
-	fi
-fi
-
+echo ""
 echo "Done."

--- a/tests/git-shed.bats
+++ b/tests/git-shed.bats
@@ -51,3 +51,24 @@ load 'test_helper'
 	[ "$status" -eq 0 ]
 	assert_output_contains "Fetching"
 }
+
+@test "git-shed: --help mentions --gone-only" {
+	run "$SCRIPTS_DIR/git-shed" --help
+	[ "$status" -eq 0 ]
+	assert_output_contains "--gone-only"
+}
+
+@test "git-shed: --gone-only skips merged branch pass" {
+	setup_git_repo
+	git switch -c feature-branch
+	echo "feature" >feature.txt
+	git add feature.txt
+	git commit -m "Add feature"
+	git switch main
+	git merge feature-branch
+
+	run "$SCRIPTS_DIR/git-shed" --gone-only --dry-run -y
+	[ "$status" -eq 0 ]
+	assert_output_not_contains "merged into"
+	git show-ref --verify --quiet refs/heads/feature-branch
+}


### PR DESCRIPTION
## Summary

- Remove linked worktrees before deleting merged or `[gone]` branches, with `--force --force` retry on lock errors
- Detect merged locals via `git for-each-ref --merged` against `origin/TARGET_BRANCH` (fallback: local target)
- Fix stale-branch parsing for `+` worktree prefix (not only `*`)
- Print `git branch -v` and `git worktree list` before cleanup
- Add `--gone-only` to skip the merged pass and only delete upstream-deleted branches

## Test plan

- [x] `SCRIPTS=git-shed PARALLEL=false ./tests/run-tests.sh` (8/8 passing)
- [ ] Manual: `git-shed --dry-run` on a repo with merged and gone branches
- [ ] Manual: `git-shed --gone-only --dry-run` skips merged listing