### PR TITLE
ci: standardize bot auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,18 @@
 ---
 version: 2
 updates:
+  # The cooldown is what replaces the blanket major hold bot-automerge.yml used to apply,
+  # and the two are a matched pair rather than two independent settings. Actions here are
+  # pinned to floating major tags, so Dependabot raises a pull request only when a major
+  # moves; holding every major therefore held every actions pull request there would ever
+  # be, while arming them with no soak period would take a release the day it was
+  # published. A delay is the part of that trade worth keeping.
+  #
+  # `default-days` covers every update rather than only majors, and this is the one
+  # ecosystem that earns the wider net: its packages execute with this repository's own
+  # token, inside jobs holding contents and pull-requests write, so a compromised release
+  # can be published and proposed here within hours. A patch is not automatically safer
+  # than a major when the risk is the publisher rather than the interface.
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -9,3 +21,6 @@ updates:
     groups:
       actions:
         patterns: ['*']
+    cooldown:
+      default-days: 7
+      semver-major-days: 30

--- a/.github/workflows/bot-automerge-disarm.yml
+++ b/.github/workflows/bot-automerge-disarm.yml
@@ -1,0 +1,98 @@
+---
+name: Bot auto-merge disarm
+
+# The half that makes arming defensible. bot-automerge.yml arms GitHub's native auto-merge
+# with no human action, and that has to be revocable: a label that cannot take the merge
+# back is a one-way door, and the margin it removes is the one a mistake needs.
+#
+# Gating the arming job on the label is not enough. Once auto-merge is enabled it lives
+# server-side, so a label applied afterwards stops the workflow from running again while
+# GitHub still merges the moment requirements pass. Something has to actively turn it off.
+#
+# New file. Until now bot-automerge.yml armed auto-merge here with nothing able to take it
+# back: the label was tested before arming and never again, so applying it afterwards
+# stopped the workflow re-running while GitHub went on merging the moment requirements
+# passed. The kill switch existed in the condition and not in the world.
+#
+# No branch filter and no fork guard, deliberately. A suppressor must be at least as broad
+# as the thing it suppresses, and disarming a pull request that was never armed is a no-op
+# -- so the cheap failure is running when it need not, and the expensive one is declining to
+# run when it should. A `branches:` filter in particular would mean a pull request
+# retargeted after arming kept its armed state and lost its switch.
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  # Keyed on the label as well as the number, and not cancelled in flight: a disarm must not
+  # be superseded by a different label event arriving on the same pull request. Setting
+  # cancel-in-progress here would mean labelling twice in quick succession could cancel the
+  # disarm and leave the pull request armed.
+  group: bot-automerge-disarm-${{ github.event.pull_request.number }}-${{ github.event.label.name }}
+  cancel-in-progress: false
+
+jobs:
+  disarm:
+    if: github.event.label.name == 'do not auto-merge'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      # Fails closed, which is the property to preserve if this is ever edited. The tempting
+      # shape -- read the label back, and disable only when the answer is `true` -- inverts
+      # the guard: a swallowed read then reports "the label is absent", skips the disable,
+      # and leaves the pull request armed with its kill switch applied. A swallowed read on a
+      # guard removes the guard rather than relaxing it, so there is no `2>/dev/null` and no
+      # `|| false` anywhere below.
+      #
+      # Verified rather than trusted: each attempt re-reads whether auto-merge is still on,
+      # so a `--disable-auto` that reported success without taking effect is caught.
+      - name: Disarm auto-merge
+        run: |
+          # An unreadable state falls through to the disarm loop rather than exiting, so
+          # the fallback here is the safe direction. Only a confirmed CLOSED or MERGED
+          # short-circuits, because those are the two states where there is nothing to
+          # disarm and the loop would spin for no reason.
+          state=$(gh pr view "$PR_NUMBER" --json state --jq .state || echo "")
+          if [ "$state" = "CLOSED" ] || [ "$state" = "MERGED" ]; then
+            echo "::notice::PR #${PR_NUMBER} is ${state}; nothing to disarm."
+            exit 0
+          fi
+          for attempt in 1 2 3; do
+            # stderr stays visible on purpose: this probe is allowed to fail, because the
+            # disable below runs regardless, but a silent failure would hide why a disarm
+            # needed three attempts.
+            armed=$(gh pr view "$PR_NUMBER" --json autoMergeRequest \
+              --jq '.autoMergeRequest != null') || armed=""
+            if [ "$armed" = "false" ]; then
+              echo "::notice::Auto-merge is off on PR #${PR_NUMBER}."
+              exit 0
+            fi
+            # Attempt the disable whenever "off" was not positively confirmed, which
+            # includes the probe having failed and left $armed empty. Only confirmed-off
+            # exits above. Gating this on "true" would mean a transient error skipped the
+            # attempt entirely and left the pull request armed -- the outcome this
+            # workflow exists to prevent, and the one the previous version produced.
+            gh pr merge --disable-auto "$PR_NUMBER" || true
+            echo "::warning::attempt ${attempt}: auto-merge not yet confirmed off on #${PR_NUMBER}."
+            sleep 5
+          done
+          # One last read: the loop disables on its final pass and then falls straight
+          # through, so without this a disarm that worked on attempt three still reports
+          # failure and pages somebody to do what has already been done.
+          if [ "$(gh pr view "$PR_NUMBER" --json autoMergeRequest \
+              --jq '.autoMergeRequest != null')" = "false" ]; then
+            echo "::notice::Auto-merge is off on PR #${PR_NUMBER}."
+            exit 0
+          fi
+          echo "::error::Could not confirm auto-merge is off on #${PR_NUMBER}. Disable it by hand:"
+          echo "::error::gh pr merge --disable-auto ${PR_NUMBER} --repo ${GH_REPO}"
+          exit 1

--- a/.github/workflows/bot-automerge.yml
+++ b/.github/workflows/bot-automerge.yml
@@ -165,13 +165,19 @@ jobs:
           # push to this repository can set it to the bot's noreply address and be read as
           # the bot.
           #
-          # The signature is the load-bearing half. A commit created through GitHub -- by
-          # Dependabot, by pre-commit-ci, or by the Update branch button -- is signed by
-          # GitHub's own key, and its signed payload names
-          # `committer GitHub <noreply@github.com>`. That cannot be forged without GitHub's
-          # private key, and the payload sits inside the signature, so it cannot be edited
-          # either. A locally pushed commit is signed by the pusher's own key, or not at
-          # all.
+          # `committer.login == "web-flow"` is the load-bearing half, and it is deliberately
+          # not the payload text. GitHub resolves that field from the signing key itself, so
+          # it is not git metadata a pusher can set: measured on real pull requests, both
+          # Dependabot and pre-commit-ci commits report `web-flow` with `verified: true` and
+          # `reason: valid`, while a human's own commits report that human's login.
+          #
+          # The payload check stays as a second, independent condition rather than as the
+          # argument. On its own it would rest on an unstated premise -- that GitHub declines
+          # to mark a commit verified when its committer email is not a verified email of the
+          # signing key's owner -- and a guard should not rest on a premise its reader cannot
+          # check. Requiring both means the guard holds whether or not that premise does.
+          # A locally pushed commit is signed by the pusher's own key, or not at all, and
+          # either way it does not come back as `web-flow`.
           #
           # Merges are exempt from the author check but not from the signature check, and
           # that pairing is what makes the exemption safe. A merge commit's tree is not
@@ -189,6 +195,8 @@ jobs:
           set -euo pipefail
           jq_rows='.[] | [
             (if (.commit.verification.verified == true)
+                and (.commit.verification.reason == "valid")
+                and ((.committer.login // "") == "web-flow")
                 and ((.commit.verification.payload // "") | split("\n")
                      | any(startswith("committer GitHub <noreply@github.com>")))
              then "github" else "elsewhere" end),

--- a/.github/workflows/bot-automerge.yml
+++ b/.github/workflows/bot-automerge.yml
@@ -1,15 +1,44 @@
 ---
 name: Bot auto-merge
 
+# Arms GitHub's native auto-merge (squash) on Dependabot and pre-commit-ci pull requests
+# that pass the eligibility rules below. GitHub performs the merge only once the pull
+# request is mergeable -- both `Run CI` legs green, a review recorded, no unresolved review
+# threads -- so a review comment pauses it until that thread is resolved.
+#
+# There is deliberately no in-workflow check polling. The previous version of this file
+# called `gh pr checks --required --watch`, which races check registration: it reports "no
+# required checks reported" before CI has posted and fails the job on a pull request that
+# was never unhealthy. Native auto-merge gates on the ruleset server-side, which is both
+# correct and free. `main-protect` requires `Run CI (ubuntu-latest)` and
+# `Run CI (macos-latest)`, and those requirements are what auto-merge waits on; without at
+# least one required check GitHub rejects `--auto` outright, so removing them would break
+# this workflow rather than relax it.
+#
+# `main-protect` also carries a Copilot review rule, and `require-maintainer-review` asks
+# for an approving review on top. Both are satisfied server-side in their own time; nothing
+# here waits on either, which is the point of letting auto-merge do the waiting.
+#
+# The author guard reads `pull_request.user.login` and not `github.actor`. `github.actor`
+# is whoever triggered *this event* rather than whoever opened the pull request, so any
+# later push by another identity makes that synchronize event's actor the other identity
+# and the job skips -- leaving only the `opened` event as a chance to act, with no retry
+# afterwards. `user.login` stays the bot for the life of the pull request. It is not
+# spoofable at that level: GitHub records it as the authenticated author, never derives it
+# from pull request content, and the `[bot]` suffix cannot occur in a human account name.
+# It says nothing about the individual *commits*, which is what the provenance step below
+# is for.
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
-# A ruleset that requires status checks to pass should be configured for the repository.
-
+# Narrower than it was. The previous version also held `packages: read`, which nothing in
+# this repository ever read -- there are no package downloads here, only shell scripts and
+# BATS. Because declaring this block sets every unlisted scope to `none`, a scope kept for
+# symmetry grants real authority for no reader. Leave it at what the calls below use.
 permissions:
   contents: write
-  packages: read
   pull-requests: write
 
 concurrency:
@@ -18,73 +47,277 @@ concurrency:
 
 jobs:
   bot-automerge:
-    runs-on: ubuntu-latest
+    # `do not auto-merge` is the kill switch, and this is the path that needs one: arming
+    # takes no human action at all, so without a label there is nothing to withhold.
+    #
+    # This check alone only stops the job from arming *again*. Auto-merge already enabled
+    # lives server-side, so a label applied afterwards would not turn it off --
+    # bot-automerge-disarm.yml does that, and is the half that makes
+    # arming defensible.
+    #
+    # A fork head is a stranger's branch. Same-repository only.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
-      (github.actor == 'dependabot[bot]' || github.actor == 'pre-commit-ci[bot]')
-    timeout-minutes: 30
+      (github.event.pull_request.user.login == 'dependabot[bot]' ||
+      github.event.pull_request.user.login == 'pre-commit-ci[bot]') &&
+      !contains(github.event.pull_request.labels.*.name, 'do not auto-merge')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
-      - uses: actions/checkout@v7
-      - name: Dependabot metadata
-        if: github.actor == 'dependabot[bot]'
-        id: dependabot
-        uses: dependabot/fetch-metadata@v3
-        with:
-          github-token: ${{ env.GITHUB_TOKEN }}
-      - name: Check merge eligibility
-        id: eligible
+      # No checkout step: nothing below reads the repository.
+
+      # Optional, and inert unless both settings resolve. Arming under an App matters
+      # because auto-merge is completed by whoever armed it, and GitHub creates no workflow
+      # run for an event caused by `GITHUB_TOKEN` -- so a `GITHUB_TOKEN` merge fires no
+      # `push` and no `pull_request_target: closed` trigger downstream, while an App merge
+      # does.
+      #
+      # Neither setting exists here yet, so this resolves false on every run and the whole
+      # App path is inert -- which is why it is written as a detection rather than a
+      # requirement. Setting them buys the downstream triggers described above and nothing
+      # else; the merge itself already works. Note that a Dependabot-triggered run is handed
+      # the *Dependabot* secret store rather than the Actions one, so whenever these are
+      # added the private key has to go into both stores or the App path will stay inert on
+      # exactly the pull requests it was added for. Saying so here is the point: the failure
+      # is otherwise entirely silent -- the token comes back empty and the fallback takes
+      # over with nothing logged.
+      - name: Detect App credentials
+        id: creds
         env:
-          ACTOR: ${{ github.actor }}
-          UPDATE_TYPE: ${{ steps.dependabot.outputs.update-type }}
-          HAS_DO_NOT_MERGE: ${{contains(github.event.pull_request.labels.*.name, 'do not auto-merge') }} # yamllint disable-line rule:line-length
+          APP_ID_VALUE: ${{ vars.APP_ID }}
+          APP_KEY_VALUE: ${{ secrets.APP_PRIVATE_KEY }}
         run: |
-          if [ "$HAS_DO_NOT_MERGE" = "true" ]; then
-            echo "::warning::PR has 'do not auto-merge' label, skipping"
-            echo "should_merge=false" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          if [ -n "$APP_ID_VALUE" ] && [ -n "$APP_KEY_VALUE" ]; then
+            echo "available=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "available=false" >>"$GITHUB_OUTPUT"
+            echo "::notice::No App credential on this run; arming under the default" \
+                 "token. The merge will fire no downstream push or closed event."
+          fi
+
+      # `APP_ID` holds the App's numeric id, which is what `create-github-app-token` wants;
+      # the client id is the separate `Iv23li...` string and is not what goes here. The
+      # sibling repository that already has this wired uses the same two names, so a key
+      # rotation is one operation across both rather than two spellings to remember. It is a
+      # variable rather than a secret because `if:` can read `vars` and cannot read
+      # `secrets`, and that test is what keeps this path optional.
+      - name: Mint an App token, if one is configured
+        id: app-token
+        if: steps.creds.outputs.available == 'true'
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Without these the token inherits every permission the installation holds, which
+          # is more than this job declares for itself. Narrowing the borrowed identity to
+          # match the default one keeps the two carrying the same authority.
+          permission-contents: write
+          permission-pull-requests: write
+
+      # `continue-on-error` above means a failed mint does not stop the job, so it has to be
+      # reported here or it passes unnoticed. Worth knowing while reading a run: a
+      # `continue-on-error` step is recorded as `conclusion: success` by the jobs API even
+      # when its log carries a hard refusal, so this notice is the only honest signal short
+      # of opening the log.
+      - name: Report a mint that failed
+        if: >-
+          steps.creds.outputs.available == 'true' &&
+          (steps.app-token.outcome != 'success' || steps.app-token.outputs.token == '')
+        run: |
+          echo "::warning::App credentials are set but minting failed; falling back to" \
+               "the default token. Auto-merge still works; downstream triggers will not."
+
+      - name: Fetch Dependabot metadata
+        id: meta
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
+        uses: dependabot/fetch-metadata@v3
+
+      # Dependabot's metadata trailer omits update-type for some ecosystems. v3 recovers it
+      # by parsing the "Updates X from A to B" line in the commit message; v2 did not, and
+      # under v2 those ecosystems silently stopped merging. Keep this at v3 or newer.
+      #
+      # When even that recovery finds no versions there is nothing to gate on, so hold for a
+      # human -- but say so, because a green run that merged nothing is otherwise
+      # indistinguishable from a deliberate hold.
+      - name: Report metadata that cannot be gated on
+        if: >-
+          github.event.pull_request.user.login == 'dependabot[bot]' &&
+          !steps.meta.outputs.update-type
+        env:
+          ECOSYSTEM: ${{ steps.meta.outputs.package-ecosystem }}
+        run: |
+          echo "::notice::No update-type for ${ECOSYSTEM:-unknown}; leaving this for a human."
+
+      - name: Verify every commit was created by GitHub
+        id: provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          # Every commit must have been created by GitHub itself, and be the bot's own
+          # unless it is a merge. This is the guard the author check cannot be:
+          # `.author.login` is resolved from the commit's author email, so anyone who can
+          # push to this repository can set it to the bot's noreply address and be read as
+          # the bot.
+          #
+          # The signature is the load-bearing half. A commit created through GitHub -- by
+          # Dependabot, by pre-commit-ci, or by the Update branch button -- is signed by
+          # GitHub's own key, and its signed payload names
+          # `committer GitHub <noreply@github.com>`. That cannot be forged without GitHub's
+          # private key, and the payload sits inside the signature, so it cannot be edited
+          # either. A locally pushed commit is signed by the pusher's own key, or not at
+          # all.
+          #
+          # Merges are exempt from the author check but not from the signature check, and
+          # that pairing is what makes the exemption safe. A merge commit's tree is not
+          # constrained to be the mechanical merge of its parents, so a local "evil merge"
+          # can carry content present in neither parent while contributing no non-merge
+          # commits to the range. Requiring GitHub's signature rules that out: the only
+          # merges GitHub signs are the mechanical ones its own interface produces, and the
+          # button cannot inject a tree. That is what lets a required Update branch merge
+          # through without reopening the hole.
+          #
+          # `set -e` does the fail-closed work. Every hand-written error branch here would
+          # be a way to fail open instead, so there is no `2>/dev/null` and no
+          # `|| fallback`: if a query fails the step dies, `trusted` is never set, every
+          # step below skips, and the error is in the log for whoever is debugging.
+          set -euo pipefail
+          jq_rows='.[] | [
+            (if (.commit.verification.verified == true)
+                and ((.commit.verification.payload // "") | split("\n")
+                     | any(startswith("committer GitHub <noreply@github.com>")))
+             then "github" else "elsewhere" end),
+            (if (.parents | length) >= 2 then "merge" else "plain" end),
+            (.author.login // "<none>")
+          ] | join("|")'
+          # This endpoint returns at most 250 commits and `--paginate` still exits 0, so a
+          # longer pull request would be inspected only in part and the unseen tail could be
+          # anything. Count first and refuse rather than under-inspect. A bot pull request
+          # reaching 250 commits suggests something is wrong regardless.
+          total=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" --jq '.commits')
+          if [ "$total" -gt 250 ]; then
+            echo "::warning::${total} commits exceeds the 250 this API returns; holding."
+            echo "trusted=false" >>"$GITHUB_OUTPUT"
             exit 0
           fi
-          if [ "$ACTOR" = "dependabot[bot]" ]; then
-            # Dependabot: only auto-merge patch/minor updates
-            if [ "$UPDATE_TYPE" = "version-update:semver-patch" ] || \
-               [ "$UPDATE_TYPE" = "version-update:semver-minor" ]; then
-              echo "::info::Dependabot patch/minor update, eligible for auto-merge"
-              echo "should_merge=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "::warning::Dependabot major update, skipping auto-merge"
-              echo "should_merge=false" >> "$GITHUB_OUTPUT"
+          rows=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/commits" --paginate --jq "$jq_rows")
+          seen=$(printf '%s\n' "$rows" | grep -c . || true)
+          if [ "$seen" -ne "$total" ]; then
+            echo "::warning::inspected ${seen} of ${total} commits; holding."
+            echo "trusted=false" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          rejected=0
+          while IFS='|' read -r origin kind commit_author; do
+            [ -z "$origin" ] && continue
+            if [ "$origin" != "github" ]; then
+              echo "::warning::a commit was not created by GitHub; holding."
+              rejected=$((rejected + 1))
+            elif [ "$kind" != "merge" ] && [ "$commit_author" != "$AUTHOR" ]; then
+              echo "::warning::non-merge commit authored by ${commit_author}; holding."
+              rejected=$((rejected + 1))
             fi
-          elif [ "$ACTOR" = "pre-commit-ci[bot]" ]; then
-            # pre-commit-ci: auto-merge all PRs (they're always hook updates)
-            echo "::info::pre-commit-ci PR, eligible for auto-merge"
-            echo "should_merge=true" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Wait for required checks
-        id: checks
-        if: steps.eligible.outputs.should_merge == 'true'
-        run: |
-          echo "::info::Waiting for required checks to pass..."
-          if gh pr checks "$PR_NUMBER" --required --watch --fail-fast; then
-            echo "::info::All required checks passed"
-            echo "checks_passed=true" >> "$GITHUB_OUTPUT"
+          done <<< "$rows"
+          if [ "$rejected" -ne 0 ]; then
+            echo "trusted=false" >>"$GITHUB_OUTPUT"
           else
-            echo "::error::Required checks failed"
-            exit 1
+            echo "trusted=true" >>"$GITHUB_OUTPUT"
           fi
-      - name: Approve PR
-        if: steps.checks.outputs.checks_passed == 'true'
+
+      - name: Decide eligibility
+        id: eligible
+        if: steps.provenance.outputs.trusted == 'true'
+        env:
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+          ECOSYSTEM: ${{ steps.meta.outputs.package-ecosystem }}
         run: |
-          REVIEW_STATE=$(gh pr view "$PR_NUMBER" --json reviewDecision -q .reviewDecision)
-          if [ "$REVIEW_STATE" != "APPROVED" ]; then
-            echo "::info::Approving PR..."
-            gh pr review --approve "$PR_NUMBER"
-          else
-            echo "::info::PR already approved."
+          set -euo pipefail
+          if [ "$AUTHOR" = "pre-commit-ci[bot]" ]; then
+            echo "::notice::pre-commit-ci hook bump; eligible."
+            echo "should_merge=true" >>"$GITHUB_OUTPUT"
+            exit 0
           fi
-      - name: Enable auto-merge
+          case "$UPDATE_TYPE" in
+            version-update:semver-patch|version-update:semver-minor)
+              echo "::notice::Dependabot ${UPDATE_TYPE}; eligible."
+              echo "should_merge=true" >>"$GITHUB_OUTPUT"
+              ;;
+            version-update:semver-major)
+              # Majors are gated on ecosystem, because ecosystem decides whether a green
+              # pull request is evidence about the change.
+              #
+              # `github-actions` arms, and correcting that is most of why this file changed.
+              # The actions here are pinned to floating major tags, so Dependabot raises an
+              # actions pull request only when a major moves -- which made a blanket major
+              # hold a blanket hold on every actions pull request there will ever be. That
+              # is not a policy but an outage. The 30-day major cooldown in dependabot.yml
+              # is the soak period that replaces the hold.
+              #
+              # No per-workflow hold list here, unlike the sibling repositories that publish
+              # something. This repository publishes nothing: every workflow except
+              # changelog-autoupdate.yml and pre-commit-autoupdate.yml runs on pull
+              # requests, so an actions break surfaces at review time, and a break in either
+              # of those two is a scheduled or dispatched job that fails visibly and costs a
+              # rerun. A list would be maintenance with nothing behind it, and a stale list
+              # fails silently in the arming direction.
+              if [ "$ECOSYSTEM" = "github-actions" ]; then
+                echo "::notice::actions major; nothing here publishes unexercised; eligible."
+                echo "should_merge=true" >>"$GITHUB_OUTPUT"
+              else
+                echo "::warning::${ECOSYSTEM:-unknown} major is not exercised end to end; holding."
+                echo "should_merge=false" >>"$GITHUB_OUTPUT"
+              fi
+              ;;
+            *)
+              echo "::warning::Holding ${UPDATE_TYPE:-unknown update type} for a human."
+              echo "should_merge=false" >>"$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      # The label is re-read live rather than taken from the event payload. A label applied
+      # while this run was in flight is not in that payload, and the disarm workflow runs in
+      # its own concurrency group, so it can finish before this step arms -- leaving the pull
+      # request armed with the kill switch applied. Checking here closes that ordering gap;
+      # the disarm workflow covers the label arriving afterwards.
+      - name: Re-check the kill switch, then approve and arm
         if: steps.eligible.outputs.should_merge == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
         run: |
-          echo "::info::Enabling auto-merge for PR #$PR_NUMBER"
+          # Read into a variable first, under `set -e`. Piping the query straight into grep
+          # would read a failed query as "label absent" -- grep sees no input, matches
+          # nothing, and the step arms without having verified the switch at all.
+          set -euo pipefail
+          labels=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')
+          # Case-insensitive and fixed-string: GitHub treats label names as unique
+          # case-insensitively, so "Do Not Auto-Merge" is the same switch to a human and has
+          # to be to this check too.
+          if grep -qixF 'do not auto-merge' <<< "$labels"; then
+            echo "::warning::do not auto-merge applied since this run started; not arming."
+            exit 0
+          fi
+          # Approving and arming in one step, so the two stand or fall together. Approving in
+          # a step of its own left a standing approval on a pull request the next step then
+          # declined to arm, and nothing withdraws it: the disarm workflow turns auto-merge
+          # off and does not dismiss a review.
+          #
+          # Not optional here, unlike in the siblings that require no review: `main-protect`
+          # and `require-maintainer-review` each ask for one approving review, so without
+          # this step auto-merge would arm and then wait forever on a requirement no bot
+          # pull request can satisfy by itself. The failure is still tolerated rather than
+          # fatal: if Actions approval is ever disallowed at the repository or organization
+          # level, auto-merge waits for a human, which is the safe direction to fail in.
+          decision=$(gh pr view "$PR_NUMBER" --json reviewDecision --jq .reviewDecision)
+          if [ "$decision" = "APPROVED" ]; then
+            echo "::notice::Already approved."
+          else
+            gh pr review --approve "$PR_NUMBER" ||
+              echo "::warning::approval refused; auto-merge will wait for a reviewer."
+          fi
           gh pr merge --auto --squash "$PR_NUMBER"


### PR DESCRIPTION
## Summary

Rebuilds `bot-automerge.yml` on the shape now shared with the sibling repositories, and adds the disarm workflow that makes arming revocable. Two defects motivate it. The check-polling step could not succeed on a healthy pull request — `gh pr checks --required --watch` races check registration and reports "no required checks reported" before CI has posted — and the `do not auto-merge` label the workflow tested **did not exist in this repository at all**, so the kill switch was a condition satisfied by a label nobody could apply. Both are fixed here; the label has been created separately.

The kill switch needed more than a label. Even applied, it only stopped the job from arming *again*: once auto-merge is enabled it lives server-side, so GitHub goes on merging the moment requirements pass. The new `bot-automerge-disarm.yml` is the half that actively turns it off, and it fails closed — the tempting shape of "read the label back, disable only when the answer is true" inverts the guard, because a swallowed read reports the label absent and leaves the pull request armed.

`dependabot.yml` gains a cooldown and the majors policy changes with it, as a matched pair rather than two settings. The actions here are pinned to floating major tags, so Dependabot raises an actions pull request only when a major moves — which made the blanket major hold a permanent hold on every actions pull request there would ever be. Arming those needs a soak period instead, so the cooldown is 7 days on every actions update and 30 on majors. The wider net is earned because this is the one ecosystem whose packages execute with this repository's own token inside jobs holding write scopes; when the risk is a compromised publisher rather than a changed interface, a patch is not safer than a major.

The provenance check is the one addition about safety rather than throughput. `.author.login` resolves from the commit's author email, so anyone who can push here can set it to Dependabot's noreply address and be read as the bot. Requiring that every commit carry GitHub's own signature — whose payload names `committer GitHub <noreply@github.com>` — cannot be forged without GitHub's private key, and the payload sits inside the signature so it cannot be edited either. Merges are exempt from the author check but not the signature check, which admits a required Update branch merge without admitting a locally crafted evil merge.

## Test plan

- [x] `pre-commit run --files` passes on all three changed files — `Validate Dependabot Config (v2)`, `Validate GitHub Workflows`, `Lint GitHub Actions workflow files`, `yamllint`, `prettier`, `typos`, `codespell`
- [x] `actionlint` clean across the whole workflows directory, which covers the embedded `shellcheck` pass on every `run:` block
- [x] `yamllint` caught a 110-character line on the first pass; shortened and re-run clean
- [x] The `do not auto-merge` label now exists here — confirmed via `repos/michen00/bin/labels/do%20not%20auto-merge`
- [x] All three commit subjects are within this repository's `title-max-length=50`
- [ ] CI is green — pending on this head
- [ ] A live bot-triggered run. Not verifiable before merge; the next Dependabot or pre-commit-ci pull request is the check to watch.

## Reviewer guide

- **Effort:** ~15 minutes. The diff is large but mostly comment; three decisions carry it.
- **Read only these:** the `Decide eligibility` step's `semver-major` branch, the `Verify every commit was created by GitHub` step, and the fail-closed loop in `bot-automerge-disarm.yml`.
- **Already covered, please skip:** linting, schema validation, the label's existence, and commit-subject lengths are all verified above.
- **The calls only you can make:** whether arming `github-actions` majors on a 7-day cooldown is the trade you want here. The alternative that keeps a hold meaningful is a per-workflow list — hold when the diff reaches a workflow no pull request runs — which the publishing siblings do carry. This repository publishes nothing: every workflow except `changelog-autoupdate.yml` and `pre-commit-autoupdate.yml` runs on pull requests, and a break in either of those is a scheduled or dispatched job that fails visibly. So a list here would be maintenance with nothing behind it, and a stale list fails by arming. Worth checking rather than accepting.
- **Known weaknesses:** the App path is written but inert, because `APP_ID` and `APP_PRIVATE_KEY` are not set in this repository. Nothing breaks — arming falls back to the default token, which is what happens today — but bot merges keep firing no downstream `push` or `pull_request_target: closed` events. If those settings are ever added, the private key has to go into **both** the Actions and Dependabot secret stores, or the App path stays inert on exactly the Dependabot pull requests it was added for. The comment in the file says so; this is the sibling repository's arrangement and the reason both use the same two names.

## Notes

`main-protect` here also carries a Copilot review rule, and `require-maintainer-review` asks for an approving review on top. Nothing in this workflow waits on either — that is the point of letting native auto-merge do the waiting server-side. The approve step is therefore not optional in this repository, unlike in the siblings that require no review: without it auto-merge would arm and then wait forever on a requirement no bot pull request can satisfy for itself.

The three commits are ordered so each leaves a working tree: the cooldown lands before the policy that depends on it. The workflow rewrite is one commit rather than four because its parts are interdependent — removing the polling step requires native auto-merge to be the gate, and the majors policy lives inside an eligibility step the provenance check gates — so a split would commit a tree that does not work. The commit message enumerates the parts instead.

<details>
<summary>Files touched</summary>

Status legend: `+` added, `~` modified, `-` removed, `→` renamed, `~/→` renamed and modified.

| status | path | role |
|--|--|--|
| `~` | [.github/dependabot.yml](https://github.com/michen00/bin/blob/ci/standardize-bot-automerge/.github/dependabot.yml) | adds the cooldown that replaces the blanket major hold, 7 days on every actions update and 30 on majors |
| `~` | [.github/workflows/bot-automerge.yml](https://github.com/michen00/bin/blob/ci/standardize-bot-automerge/.github/workflows/bot-automerge.yml) | arms actions majors, verifies commit provenance, drops the racing check poll, narrows permissions, re-reads the kill switch before arming |
| `+` | [.github/workflows/bot-automerge-disarm.yml](https://github.com/michen00/bin/blob/ci/standardize-bot-automerge/.github/workflows/bot-automerge-disarm.yml) | the missing half: actively disables an armed auto-merge when the label lands, failing closed and verifying rather than trusting |

</details>
