### PR TITLE
fix: use the cooldown key actions accepts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,5 +22,17 @@ updates:
       actions:
         patterns: ['*']
     cooldown:
-      default-days: 7
-      semver-major-days: 30
+      # default-days only. GitHub rejects the semver-* keys for this ecosystem --
+      # "not supported for the package ecosystem 'github-actions'" -- and an
+      # invalid key here does not degrade gracefully: it invalidates the file and
+      # drops this whole entry, grouping and ignore rules included. The
+      # check-dependabot schema hook does not catch it, because the rejection is
+      # server-side rather than schematic.
+      #
+      # So one number covers every actions update, and 30 days is chosen over a
+      # shorter delay because bot-automerge.yml now arms actions majors: this is
+      # the only soak period between a release being published and it merging
+      # here unattended. A patch is not safer than a major when the risk is a
+      # compromised publisher rather than a changed interface, and these packages
+      # execute with this repository's own token inside jobs holding write scopes.
+      default-days: 30

--- a/.github/workflows/bot-automerge.yml
+++ b/.github/workflows/bot-automerge.yml
@@ -264,8 +264,15 @@ jobs:
               # The actions here are pinned to floating major tags, so Dependabot raises an
               # actions pull request only when a major moves -- which made a blanket major
               # hold a blanket hold on every actions pull request there will ever be. That
-              # is not a policy but an outage. The 30-day major cooldown in dependabot.yml
-              # is the soak period that replaces the hold.
+              # is not a policy but an outage. The cooldown in dependabot.yml is the soak
+              # period that replaces the hold -- and it covers every actions update rather
+              # than only majors, because that ecosystem accepts no major-specific key.
+              #
+              # Its effective length is longer than the number suggests, which is worth
+              # knowing before tuning it: the actions ecosystem is polled on the 1st and
+              # 15th, so an update whose cooldown expires just after a poll waits until the
+              # next one. Thirty days of cooldown therefore lands a pull request roughly
+              # thirty to forty-five days after the release.
               #
               # No per-workflow hold list here, unlike the sibling repositories that publish
               # something. This repository publishes nothing: every workflow except


### PR DESCRIPTION
## Summary

Replaces `semver-major-days` with `default-days` on the `github-actions` ecosystem, because that ecosystem does not accept the `semver-*` keys and the failure is silent and total rather than partial.

GitHub rejects `semver-major-days` for `github-actions` with *"not supported for the package ecosystem 'github-actions'"*, and [the options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference) confirms it: `default-days` is supported for every package manager, while `semver-major-days`, `semver-minor-days` and `semver-patch-days` are supported only for the ecosystems it lists, and `github-actions` is not among them. An invalid key does not degrade to "cooldown ignored" — it invalidates the file and drops the whole `github-actions` entry, **grouping and ignore rules included**. So a key added to introduce a soak period removes the grouping instead, and the visible symptom is one pull request per action rather than one per group.

This is a self-inflicted regression and worth saying so plainly: the invalid key arrived in the pull request that standardized this workflow, and it merged because the `check-dependabot` pre-commit hook passes on it. That hook validates against the published schema, and the schema admits `semver-major-days` in a `cooldown` block generally — the ecosystem restriction is enforced server-side, so no local gate can catch it. A sibling repository had already hit this and recorded the diagnosis in its own config; that comment is where this fix came from.

One number therefore has to cover every actions update. 30 days rather than something shorter, because `bot-automerge.yml` now arms `github-actions` majors instead of holding them — this delay is the only soak period between a release being published and it merging here unattended. A patch is not safer than a major when the risk is a compromised publisher rather than a changed interface, and these packages execute with this repository's own token inside jobs holding write scopes.

A review on this pull request raised two further things, both acted on in a follow-up commit. The workflow comment still described a *"30-day major cooldown"*, which stopped being true the moment the key changed — the one place a reader is told how the arming policy and the cooldown fit together was describing a key that is not there. And the effective delay is longer than the number: this ecosystem is polled on the 1st and 15th, so an update whose cooldown expires just after a poll waits for the next one, putting a pull request roughly 30–45 days after the release rather than 30. That is recorded rather than retuned, because shortening the cooldown to compensate would couple two independent settings and the drift is in the safe direction.

## Test plan

- [x] Confirmed against GitHub's own options reference that `github-actions` supports `default-days` only
- [x] Audited every sibling repository for the same key, so this is fixed across the set rather than here alone
- [x] `pre-commit run --files .github/dependabot.yml` passes — noted above as insufficient, and recorded here because passing is exactly what made this reachable
- [x] The commit carries a verified signature
- [x] `actionlint` and `yamllint` clean on the workflow comment change
- [ ] CI is green — pending on this head
- [ ] The real confirmation is the next `github-actions` pull request arriving **grouped**. That cannot be observed before merge, and it is the check to make afterwards: one grouped pull request means the entry is being read, several ungrouped ones mean it is still being dropped.

## Reviewer guide

- **Effort:** ~2 minutes. One key renamed and one value changed; the rest is the comment explaining why.
- **The calls only you can make:** whether 30 days is the right single delay now that one number has to serve every actions update. The alternative is a short delay accepting that majors merge quickly, or reverting to a blanket major hold in the workflow and a short cooldown here. 30 was chosen because majors now arm unattended.
- **Known weaknesses:** nothing local can catch a recurrence. The schema hook admits the invalid key and the rejection only appears server-side, in the Dependabot tab, as a config error on a file that otherwise looks fine.
